### PR TITLE
added surface pressure to outputs for MMF reference

### DIFF
--- a/climsim_scripts/mmf_speed_eval_gpu_nersc.py
+++ b/climsim_scripts/mmf_speed_eval_gpu_nersc.py
@@ -164,7 +164,7 @@ cb_strato_water_constraint = {f_cb_strato_water_constraint}
 &cam_history_nl
 fincl1 = 'CLDICE', 'CLDLIQ'
 fincl2 = 'PRECT', 'PRECC', 'FLUT', 'CLOUD', 'CLDTOT', 'CLDLOW', 'CLDMED', 'CLDHGH', 'LWCF', 'SWCF', 'LHFLX', 'SHFLX', 'TMQ', 'U850', 'T850', 'Z850', 'U500', 'T500', 'Z500', 'T', 'Q', 'U', 'V', 'CLDICE', 'CLDLIQ'
-fincl3 = 'PRECT', 'PRECC', 'FLUT', 'CLOUD', 'CLDTOT', 'CLDLOW', 'CLDMED', 'CLDHGH', 'LWCF', 'SWCF', 'LHFLX', 'SHFLX', 'TMQ', 'T', 'Q', 'U', 'V', 'CLDICE', 'CLDLIQ'
+fincl3 = 'PRECT', 'PRECC', 'FLUT', 'CLOUD', 'CLDTOT', 'CLDLOW', 'CLDMED', 'CLDHGH', 'LWCF', 'SWCF', 'LHFLX', 'SHFLX', 'TMQ', 'T', 'Q', 'U', 'V', 'CLDICE', 'CLDLIQ', 'PS'
 avgflag_pertape = 'A','A','I'
 nhtfrq = 0,-24,-1
 mfilt  = 0,1,1

--- a/components/eam/src/physics/cam/cam_diagnostics.F90
+++ b/components/eam/src/physics/cam/cam_diagnostics.F90
@@ -330,6 +330,7 @@ subroutine diag_init()
    call addfld ('DQ2PHYS',(/ 'lev' /), 'A','kg/kg/s','dQ2/dt from physics')
    call addfld ('DQ3PHYS',(/ 'lev' /), 'A','kg/kg/s','dQ3/dt from physics')
    call addfld ('DUPHYS',(/ 'lev' /), 'A','m/s/s','dU/dt from physics')
+   call addfld ('PS', horiz_only, 'A', 'Pa', 'Surface pressure')
 #endif
 
    call addfld ('fixerCLUBB',horiz_only,    'A','J/m2','dTE fixed by CLUBB')
@@ -1543,6 +1544,10 @@ end subroutine diag_conv_tend_ini
 
    if (hist_fld_active('DUPHYS')) then
       call outfld('DUPHYS   ',state%u_phy(1,:,:), pcols, lchnk)
+   end if
+
+   if (hist_fld_active('PS')) then
+      call outfld('PS   ',state%ps(1,:,:), pcols, lchnk)
    end if
 #endif
 


### PR DESCRIPTION
Adding surface pressure to variable list for MMF runs so that global maps can properly mass weight. Need to double check with Liran to ensure this was done correctly.